### PR TITLE
Update `Take Snapshot` to work as Subtree

### DIFF
--- a/src/picknik_ur_site_config/objectives/take_snapshot.xml
+++ b/src/picknik_ur_site_config/objectives/take_snapshot.xml
@@ -5,7 +5,11 @@
         <Control ID="Sequence">
             <Action ID="GetPointCloud" topic_name="/wrist_mounted_camera/depth/color/points" message_out="{point_cloud}" />
             <Action ID="UpdatePlanningSceneService" point_cloud="{point_cloud}" point_cloud_service="/point_cloud_service"/>
-            <Action ID="GetStringFromUser" parameter_name="take_snapshot.uuid" parameter_value="{uuid}" />  
+            <Control ID="Fallback" name="TryGetStringFromUser">
+                <Action ID="GetStringFromUser" parameter_name="take_snapshot.uuid" parameter_value="{uuid}" />
+                <!-- if we fail to get the string from the user fallback to an empty value for the uuid -->
+                <Action ID="Script" code="uuid = ''"/>
+            </Control>
             <Action ID="SendPointCloudToUI" point_cloud="{point_cloud}" sensor_name="scene_scan_camera" pcd_topic="/pcd_pointcloud_captures" point_cloud_uuid="{uuid}"/>
         </Control>
     </BehaviorTree>

--- a/src/picknik_ur_site_config/objectives/take_snapshot.xml
+++ b/src/picknik_ur_site_config/objectives/take_snapshot.xml
@@ -8,7 +8,7 @@
             <Control ID="Fallback" name="TryGetStringFromUser">
                 <Action ID="GetStringFromUser" parameter_name="take_snapshot.uuid" parameter_value="{uuid}" />
                 <!-- if we fail to get the string from the user fallback to an empty value for the uuid -->
-                <Action ID="Script" code="uuid = ''"/>
+                <Action ID="Script" code="uuid := ''"/>
             </Control>
             <Action ID="SendPointCloudToUI" point_cloud="{point_cloud}" sensor_name="scene_scan_camera" pcd_topic="/pcd_pointcloud_captures" point_cloud_uuid="{uuid}"/>
         </Control>


### PR DESCRIPTION
This PR updates `Take Snapshot` to work as a Subtree Objective so that it can be embedded into other Objectives.

To test try adding `Take Snapshot` to an existing objective and make sure it's still successful. For example in this video I added it to "Push Button".
[take_snapshot_test.webm](https://github.com/PickNikRobotics/moveit_studio_ur_ws/assets/25058794/0ae1d513-3726-40d8-beea-03bd2b835e5f)
