### PR TITLE
Fix Gazebo package dependencies

### DIFF
--- a/src/picknik_ur_gazebo_config/package.xml
+++ b/src/picknik_ur_gazebo_config/package.xml
@@ -13,13 +13,12 @@
 
   <depend>picknik_ur_base_config</depend>
 
-  <exec_depend>moveit_ros_perception</exec_depend>
-  <exec_depend>ros_gz</exec_depend>
-  <exec_depend>ign_ros2_control</exec_depend>
-  <exec_depend>picknik_accessories</exec_depend>
+  <depend>ign_ros2_control</depend>
+  <depend>moveit_ros_perception</depend>
+  <depend>picknik_accessories</depend>
+  <depend>ros_gz</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/src/picknik_ur_gazebo_scan_and_plan_config/package.xml
+++ b/src/picknik_ur_gazebo_scan_and_plan_config/package.xml
@@ -13,13 +13,12 @@
 
   <depend>picknik_ur_gazebo_config</depend>
 
-  <exec_depend>moveit_ros_perception</exec_depend>
-  <exec_depend>ros_gz</exec_depend>
-  <exec_depend>ign_ros2_control</exec_depend>
-  <exec_depend>picknik_accessories</exec_depend>
+  <depend>ign_ros2_control</depend>
+  <depend>moveit_ros_perception</depend>
+  <depend>picknik_accessories</depend>
+  <depend>ros_gz</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>


### PR DESCRIPTION
Turns out the `ros_gz` package was only tagged as an `exec_depends` and not `depends`, so `rosdep install` was missing this package. Cool and good.