### PR TITLE
Re-add streaming controller for Gazebo configuration

### DIFF
--- a/src/picknik_ur_gazebo_config/config/config.yaml
+++ b/src/picknik_ur_gazebo_config/config/config.yaml
@@ -88,10 +88,11 @@ octomap_manager:
 ros2_control:
   controllers_active_at_startup:
     - "joint_state_broadcaster"
-    - "servo_controller"
+    - "streaming_controller"
     - "robotiq_gripper_controller"
   controllers_inactive_at_startup:
     - "joint_trajectory_controller"
+    - "servo_controller"
 
 objectives:
   # Override with a new set of waypoints based on the Gazebo world.

--- a/src/picknik_ur_gazebo_config/config/control/picknik_ur5e.ros2_control.yaml
+++ b/src/picknik_ur_gazebo_config/config/control/picknik_ur5e.ros2_control.yaml
@@ -9,6 +9,9 @@ controller_manager:
       type: position_controllers/GripperActionController
     servo_controller:
       type: joint_trajectory_controller/JointTrajectoryController
+    # Needed to initialize the robot arm at simulation startup
+    streaming_controller:
+      type: position_controllers/JointGroupPositionController
 
 joint_trajectory_controller:
   ros__parameters:
@@ -89,6 +92,20 @@ servo_controller:
         goal: 0.05
       wrist_3_joint:
         goal: 0.05
+
+streaming_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
 
 robotiq_gripper_controller:
   ros__parameters:


### PR DESCRIPTION
This makes it so the Gazebo robot arm actually moves to its starting position at startup.

Somehow the UR streaming controller being active at startup did the trick...