### PR TITLE
Fix warning in Constrained planning Objective

### DIFF
--- a/src/picknik_ur_mock_hw_config/objectives/constrained_pick_place.xml
+++ b/src/picknik_ur_mock_hw_config/objectives/constrained_pick_place.xml
@@ -9,7 +9,7 @@
         <Control ID="Sequence" name="TopLevelSequence">
           <SubTree ID="Open Gripper"/>
           <Decorator ID="RetryUntilSuccessful" num_attempts="3">
-            <Action ID="MoveToWaypoint" waypoint_name="Grasp Right" planning_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" use_all_planners="false" constraints=""/>
+            <Action ID="MoveToWaypoint" waypoint_name="Grasp Right" planning_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" use_all_planners="false"/>
           </Decorator>
           <SubTree ID="Close Gripper"/>
           <Decorator ID="RetryUntilSuccessful" num_attempts="3">


### PR DESCRIPTION
This PR fixes the console warning
`[objective_server_node_main-7] You (maybe indirectly) called BT::convertFromString() for type [std::shared_ptr<moveit_msgs::msg::Constraints_<std::allocator<void> > >], but I can't find the template specialization.` when running the `Constrained Pick and Place` Objective. 

When the port is specified as an empty string BT.cpp cant convert it to a shared pointer constraint message so to fix it I removed it from the Objective.