### PR TITLE
Replace based_on_package with new CMake macro

### DIFF
--- a/src/picknik_ur_gazebo_config/CMakeLists.txt
+++ b/src/picknik_ur_gazebo_config/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_gazebo_config)
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_studio_common REQUIRED)
+
+extend_moveit_pro_config(picknik_ur_site_config)
 
 install(
   DIRECTORY

--- a/src/picknik_ur_gazebo_config/config/config.yaml
+++ b/src/picknik_ur_gazebo_config/config/config.yaml
@@ -2,9 +2,6 @@
 #  This contains information for a unique instance of a robot.
 #
 
-# Name of the package to specialize
-based_on_package: "picknik_ur_site_config"
-
 # Optional parameters that can be read in your launch files for specific functionality
 optional_feature_params:
   gazebo_world_name: "space_station_blocks_world.sdf"

--- a/src/picknik_ur_gazebo_scan_and_plan_config/CMakeLists.txt
+++ b/src/picknik_ur_gazebo_scan_and_plan_config/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_gazebo_scan_and_plan_config)
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_studio_common REQUIRED)
+
+extend_moveit_pro_config(picknik_ur_gazebo_config)
 
 install(
   DIRECTORY

--- a/src/picknik_ur_gazebo_scan_and_plan_config/config/config.yaml
+++ b/src/picknik_ur_gazebo_scan_and_plan_config/config/config.yaml
@@ -2,9 +2,6 @@
 #  This contains information for a unique instance of a robot.
 #
 
-# Name of the package to specialize
-based_on_package: "picknik_ur_gazebo_config"
-
 # Optional parameters that can be read in your launch files for specific functionality
 optional_feature_params:
   gazebo_world_package_name: "picknik_ur_gazebo_scan_and_plan_config"

--- a/src/picknik_ur_mock_hw_config/CMakeLists.txt
+++ b/src/picknik_ur_mock_hw_config/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_mock_hw_config)
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_studio_common REQUIRED)
+
+extend_moveit_pro_config(picknik_ur_base_config)
 
 install(
   DIRECTORY

--- a/src/picknik_ur_mock_hw_config/config/config.yaml
+++ b/src/picknik_ur_mock_hw_config/config/config.yaml
@@ -1,5 +1,3 @@
-based_on_package: "picknik_ur_base_config"
-
 hardware:
 
   # Be sure to set your robot's IP address.

--- a/src/picknik_ur_site_config/CMakeLists.txt
+++ b/src/picknik_ur_site_config/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_site_config)
 
 find_package(ament_cmake REQUIRED)
+find_package(moveit_studio_common REQUIRED)
+
+extend_moveit_pro_config(picknik_ur_base_config)
 
 install(
   DIRECTORY

--- a/src/picknik_ur_site_config/config/config.yaml
+++ b/src/picknik_ur_site_config/config/config.yaml
@@ -1,5 +1,3 @@
-based_on_package: "picknik_ur_base_config"
-
 hardware:
 
   # Be sure to set your robot's IP address.


### PR DESCRIPTION
Switch to build-time inheritance of config packages instead of runtime to avoid some commonly-hit inheritance issues