### PR TITLE
Fix grasp link parent frames and add to gripper SRDF group

### DIFF
--- a/src/picknik_ur_base_config/config/moveit/picknik_ur.srdf
+++ b/src/picknik_ur_base_config/config/moveit/picknik_ur.srdf
@@ -22,6 +22,7 @@
         <link name="robotiq_85_right_finger_tip_link"/>
         <link name="robotiq_85_right_knuckle_link"/>
         <link name="robotiq_85_right_finger_link"/>
+        <link name="grasp_link"/>
         <joint name="robotiq_85_left_knuckle_joint"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->

--- a/src/picknik_ur_base_config/description/picknik_ur.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur.xacro
@@ -94,7 +94,7 @@
   <!-- This link aligns the axes of the grasp frame to our required convention for motion planning tasks. -->
   <link name="grasp_link" />
   <joint name="grasp_link_joint" type="fixed">
-    <parent link="gripper_mount_link" />
+    <parent link="robotiq_85_base_link" />
     <child link="grasp_link" />
     <origin xyz="0.0 0.0 0.134" rpy="0.0 0.0 ${pi}" />
   </joint>

--- a/src/picknik_ur_gazebo_config/config/moveit/picknik_ur_gazebo.srdf.xacro
+++ b/src/picknik_ur_gazebo_config/config/moveit/picknik_ur_gazebo.srdf.xacro
@@ -25,6 +25,7 @@
         <link name="$(arg gripper_name)_right_finger_tip_link"/>
         <link name="$(arg gripper_name)_right_knuckle_link"/>
         <link name="$(arg gripper_name)_right_finger_link"/>
+        <link name="grasp_link"/>
         <joint name="$(arg gripper_name)_left_knuckle_joint"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->

--- a/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
+++ b/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
@@ -65,7 +65,7 @@
 
   <link name="grasp_link" />
   <joint name="grasp_link_joint" type="fixed">
-    <parent link="gripper_mount_link" />
+    <parent link="robotiq_85_base_link" />
     <child link="grasp_link" />
     <origin xyz="0.0 0.0 0.134" rpy="0.0 0.0 ${pi}" />
   </joint>

--- a/src/picknik_ur_mock_hw_config/config/moveit/picknik_ur_machine_tending.srdf
+++ b/src/picknik_ur_mock_hw_config/config/moveit/picknik_ur_machine_tending.srdf
@@ -22,6 +22,7 @@
         <link name="robotiq_85_right_finger_tip_link"/>
         <link name="robotiq_85_right_knuckle_link"/>
         <link name="robotiq_85_right_finger_link"/>
+        <link name="grasp_link"/>
         <joint name="robotiq_85_left_knuckle_joint"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->

--- a/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
+++ b/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
@@ -82,7 +82,7 @@
 
   <link name="grasp_link" />
   <joint name="grasp_link_joint" type="fixed">
-    <parent link="gripper_mount_link" />
+    <parent link="robotiq_85_base_link" />
     <child link="grasp_link" />
     <origin xyz="0.0 0.0 0.134" rpy="0.0 0.0 ${pi}" />
   </joint>


### PR DESCRIPTION
This PR ensures that the gripper URDF subset and planning group is self-contained for the UI.