### PR TITLE
Remove unused `kinematics.yaml` file from `picknik_ur_base_config`

### DIFF
--- a/src/picknik_ur_base_config/config/moveit/kinematics.yaml
+++ b/src/picknik_ur_base_config/config/moveit/kinematics.yaml
@@ -1,5 +1,0 @@
-manipulator:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3


### PR DESCRIPTION
The `picknik_ur_base_config` package uses track_ik for both [kinematics](https://github.com/PickNikRobotics/moveit_studio_ur_ws/blob/2fc10c2e3c7fd8595a23d943bdee3947d8d4ae2f/src/picknik_ur_base_config/config/config.yaml#L135-L137) and [servo_kinematics](https://github.com/PickNikRobotics/moveit_studio_ur_ws/blob/2fc10c2e3c7fd8595a23d943bdee3947d8d4ae2f/src/picknik_ur_base_config/config/config.yaml#L144-L146). There's a `kinematics.yaml` file that's not used in this config (or anywhere else in this repo) that causes confusion because it refers to KDL, so we should remove it :slightly_smiling_face: 