### PR TITLE
Fix schedule problem

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   # Run every 6 hours Mon-Fri
   schedule:
-    - cron: "* */6 * * 1-5"
+    - cron: "0 */6 * * 1-5"
 
 jobs:
   setup:


### PR DESCRIPTION
Currently the schedule is run several times every six hours

> The cron expression you provided, * */6 * * 1-5, is intended to schedule a job to run every 6 hours from Monday to Friday. However, there's an issue with the expression which may cause it to not work as expected. Let's break down the cron expression:
> 
> * in the first field (minute): This means the job will run every minute.
> * */6 in the second field (hour): This sets the job to run every 6 hours.
> * in the third field (day of the month): This means the job will run every day of the month.
> * in the fourth field (month): This means the job will run every month.
> * 1-5 in the fifth field (day of the week): This means the job will run Monday to Friday.
> 
> The problem is with the first field (*). It should be set to a specific minute, otherwise, the job will attempt to run every minute of every 6th hour, which is likely not the intended behavior.
> 
> To fix this and have the job run once every 6 hours (e.g., at 00:00, 06:00, 12:00, and 18:00) from Monday to Friday, you can modify the cron expression to:
> 
> ```
> 0 */6 * * 1-5
> ```
> This sets the job to run at the 0th minute (the start) of every 6th hour, which effectively schedules it for every 6 hours, only on weekdays.

https://chat.openai.com/share/3e086ae6-3619-42ca-a6a6-0bed2f5359f1