### PR TITLE
Fix Behavior loaders

### DIFF
--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -219,6 +219,9 @@ objectives:
     # Add additional plugin loaders as needed.
     core:
       - "moveit_studio::behaviors::CoreBehaviorsLoader"
+      - "moveit_studio::behaviors::MTCCoreBehaviorsLoader"
+      - "moveit_studio::behaviors::ServoBehaviorsLoader"
+      - "moveit_studio::behaviors::VisionBehaviorsLoader"
   # Specify source folder for objectives
   # [Required]
   objective_library_paths:


### PR DESCRIPTION
Since we split up the core behaviors plugins, we need to actually load them all in config!