### PR TITLE
Set colcon defaults for user overlay image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN colcon mixin add default \
     colcon metadata update
 COPY colcon-defaults.yaml /home/${USERNAME}/.colcon/defaults.yaml
 
+# hadolint ignore=DL3002
 USER root
 
 ###################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       --from-paths src \
       --ignore-src
 
+# Set up colcon defaults for the new user
+USER ${USERNAME}
+RUN colcon mixin add default \
+    https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+    https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+COPY colcon-defaults.yaml /home/${USERNAME}/.colcon/defaults.yaml
+
+USER root
+
 ###################################################################
 # Target for the developer build which does not compile any code. #
 ###################################################################

--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -1,0 +1,16 @@
+# Contains colcon default settings for user overlay containers.
+build:
+  mixin:
+    # Enable ccache support
+    - ccache
+    # Multithreaded linker to speed up linking step during compilation
+    - lld
+    - compile-commands
+    # Debug info and build testing for dev workflows
+    - rel-with-deb-info
+    - build-testing-on
+  symlink-install: true
+test:
+  event-handlers:
+    - console_direct+
+    - desktop_notification+

--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -1,5 +1,7 @@
 # Contains colcon default settings for user overlay containers.
 build:
+  # Enable this for bidirectional syncing from the UI
+  symlink-install: true
   mixin:
     # Enable ccache support
     - ccache
@@ -9,7 +11,6 @@ build:
     # Debug info and build testing for dev workflows
     - rel-with-deb-info
     - build-testing-on
-  symlink-install: true
 test:
   event-handlers:
     - console_direct+


### PR DESCRIPTION
This PR gives users control over their own workspaces' colcon defaults.

Just note that `symlink_install: True` is necessary for bidirectional sync with the UI to work.