### PR TITLE
Increase delays for p-stop test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           . /opt/underlay_ws/install/setup.sh
           . /opt/overlay_ws/install/setup.sh
           . ./install/setup.sh
-          colcon test
+          colcon test --executor sequential
       - if: always()
         run: |
           colcon test-result --verbose

--- a/src/moveit_studio_ur_pstop_manager/src/protective_stop_manager_node.cpp
+++ b/src/moveit_studio_ur_pstop_manager/src/protective_stop_manager_node.cpp
@@ -39,7 +39,7 @@ constexpr auto kStopProgramService = "/dashboard_client/stop";
 constexpr auto kRecoveryServiceName = "recover_from_protective_stop";
 constexpr auto kSafetyModeService = "/dashboard_client/get_safety_mode";
 constexpr auto kFaultStatusTopic = "~/robot_fault_status";
-constexpr auto kServiceCallTimeout = std::chrono::duration<double>(1.0);
+constexpr auto kServiceCallTimeout = std::chrono::seconds(3.0);
 
 constexpr auto kParameterControllersDefaultActive = "controllers_default_active";
 constexpr auto kParameterControllersDefaultNotActive = "controllers_default_not_active";

--- a/src/moveit_studio_ur_pstop_manager/src/protective_stop_manager_node.cpp
+++ b/src/moveit_studio_ur_pstop_manager/src/protective_stop_manager_node.cpp
@@ -39,7 +39,7 @@ constexpr auto kStopProgramService = "/dashboard_client/stop";
 constexpr auto kRecoveryServiceName = "recover_from_protective_stop";
 constexpr auto kSafetyModeService = "/dashboard_client/get_safety_mode";
 constexpr auto kFaultStatusTopic = "~/robot_fault_status";
-constexpr auto kServiceCallTimeout = std::chrono::seconds(3.0);
+constexpr auto kServiceCallTimeout = std::chrono::duration<double>(3.0);
 
 constexpr auto kParameterControllersDefaultActive = "controllers_default_active";
 constexpr auto kParameterControllersDefaultNotActive = "controllers_default_not_active";

--- a/src/moveit_studio_ur_pstop_manager/test/launch/test_reset_ur_pstop.test.py
+++ b/src/moveit_studio_ur_pstop_manager/test/launch/test_reset_ur_pstop.test.py
@@ -93,7 +93,7 @@ def generate_test_description():
                 description="Binary directory of package "
                 "containing test executables",
             ),
-            TimerAction(period=1.0, actions=[reset_ur_pstop_gtest]),
+            TimerAction(period=10.0, actions=[reset_ur_pstop_gtest]),
             launch_testing.actions.ReadyToTest(),
         ]
     ), {


### PR DESCRIPTION
We have been seeing flakiness in the p-stop test, so cranking up some timeouts / delays.

NOTE: I had to fall to `--executor sequential` because the integration and p-stop tests were clashing with each other ☹️ 