### PR TITLE
Fix UR location for Mock HW

### DIFF
--- a/src/picknik_ur_base_config/description/picknik_ur.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur.xacro
@@ -24,7 +24,9 @@
   <xacro:include filename="$(arg environment_xacro)"/>
 
   <!-- Robot: contains robot description from the world frame to the tool frame -->
-  <xacro:picknik_ur parent="world"  child="tool0" initial_positions_file="$(arg initial_positions_file)" />
+  <xacro:picknik_ur parent="world"  child="tool0" initial_positions_file="$(arg initial_positions_file)" >
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:picknik_ur>
 
   <!-- Gripper and UR adapter and realsense camera -->
   <xacro:picknik_ur_attachments parent="tool0" child="grasp_link" has_tool_changer="$(arg has_tool_changer)"/>

--- a/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
@@ -57,7 +57,7 @@
                 script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
                 output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
                 input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt">
-            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <origin xyz="0 0 0" rpy="0 0 1.57"/>
         </xacro:ur_robot>
 
         <xacro:unless value="$(arg has_tool_changer)">

--- a/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
@@ -57,7 +57,7 @@
                 script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
                 output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
                 input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt">
-            <origin xyz="0 0 0" rpy="0 0 1.57"/>
+            <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
         </xacro:ur_robot>
 
         <xacro:unless value="$(arg has_tool_changer)">

--- a/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-    <xacro:macro name="picknik_ur" params="parent child initial_positions_file">
+    <xacro:macro name="picknik_ur" params="parent child initial_positions_file *origin">
         <!-- parameters -->
         <xacro:arg name="use_fake_hardware" default="false"/>
         <xacro:arg name="external_camera" default="false"/>
@@ -57,7 +57,11 @@
                 script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
                 output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
                 input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt">
+<<<<<<< Updated upstream
             <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
+=======
+            <xacro:insert_block name="origin" />
+>>>>>>> Stashed changes
         </xacro:ur_robot>
 
         <xacro:unless value="$(arg has_tool_changer)">

--- a/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur_macro.xacro
@@ -57,11 +57,7 @@
                 script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
                 output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
                 input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt">
-<<<<<<< Updated upstream
-            <origin xyz="0 0 0" rpy="0 0 ${pi/2}"/>
-=======
             <xacro:insert_block name="origin" />
->>>>>>> Stashed changes
         </xacro:ur_robot>
 
         <xacro:unless value="$(arg has_tool_changer)">

--- a/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
+++ b/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
@@ -27,7 +27,9 @@
   <xacro:include filename="$(arg environment_xacro)"/>
 
   <!-- Robot: contains robot description from the world frame to the tool frame -->
-  <xacro:picknik_ur parent="world"  child="tool0" initial_positions_file="$(arg initial_positions_file)" />
+  <xacro:picknik_ur parent="world"  child="tool0" initial_positions_file="$(arg initial_positions_file)">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:picknik_ur>
 
   <!-- Gripper and UR adapter and realsense camera -->
   <xacro:picknik_ur_attachments parent="tool0" child="grasp_link" has_tool_changer="$(arg has_tool_changer)"/>

--- a/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
+++ b/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
@@ -24,7 +24,9 @@
     <xacro:include filename="$(arg environment_xacro)"/>
 
     <!-- Robot: contains robot description from the world frame to the tool frame -->
-    <xacro:picknik_ur parent="world"  child="tool0" initial_positions_file="$(arg initial_positions_file)" />
+    <xacro:picknik_ur parent="world"  child="tool0" initial_positions_file="$(arg initial_positions_file)">
+      <origin xyz="0 0 0" rpy="0 0 ${pi/2}" />
+    </xacro:picknik_ur>
 
     <!-- Gripper and UR adapter and realsense camera -->
     <xacro:picknik_ur_attachments parent="tool0" child="grasp_link" has_tool_changer="$(arg has_tool_changer)"/>


### PR DESCRIPTION
The UR seemed to be rotated 90 to the right in mock hw config and hence the waypoints were off. 
