### PR TITLE
Add coverage mixins to colcon defaults file

### DIFF
--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -11,6 +11,8 @@ build:
     # Debug info and build testing for dev workflows
     - rel-with-deb-info
     - build-testing-on
+    - coverage-gcc
+    - coverage-pytest
 test:
   event-handlers:
     - console_direct+


### PR DESCRIPTION
While testing a workspace with custom Behaviors, I realized we will need this too.