### PR TITLE
Replace moveit_studio_test_utils with moveit_studio_common

### DIFF
--- a/src/picknik_ur_studio_integration_testing/package.xml
+++ b/src/picknik_ur_studio_integration_testing/package.xml
@@ -14,7 +14,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>moveit_studio_agent</test_depend>
-  <test_depend>moveit_studio_test_utils</test_depend>
+  <test_depend>moveit_studio_common</test_depend>
   <test_depend>moveit_studio_ur_pstop_manager</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>ros_testing</test_depend>

--- a/src/picknik_ur_studio_integration_testing/test/CMakeLists.txt
+++ b/src/picknik_ur_studio_integration_testing/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(rclcpp REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 find_package(moveit_studio_agent REQUIRED)
-find_package(moveit_studio_test_utils REQUIRED)
+find_package(moveit_studio_common REQUIRED)
 find_package(ros_testing REQUIRED)
 
 # Integration test for ObjectiveServerNode running with other Agent nodes using real Behaviors


### PR DESCRIPTION
This PR addresses some changes in the package dependencies upstream to make CI pass again.

... while technically this package doesn't seem to be required, I think it's good to share in a general integration testing example, which this serves as. But we can also straight up delete these lines if preferable.