### PR TITLE
Bump to version `5.0.0`


### DIFF
--- a/src/moveit_studio_ur_pstop_manager/package.xml
+++ b/src/moveit_studio_ur_pstop_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_studio_ur_pstop_manager</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
   <description>Provides a node to monitor the protective stop state of the UR5, and reset protective
     stops when necessary.</description>
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>

--- a/src/picknik_ur_base_config/package.xml
+++ b/src/picknik_ur_base_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>picknik_ur_base_config</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
 
   <description>Base configuration package for Picknik's UR robot arms</description>
 

--- a/src/picknik_ur_gazebo_config/package.xml
+++ b/src/picknik_ur_gazebo_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>picknik_ur_gazebo_config</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
 
   <description>Site configuration package for the UR5e in PickNik's space station world simulated by Gazebo.</description>
 

--- a/src/picknik_ur_gazebo_scan_and_plan_config/package.xml
+++ b/src/picknik_ur_gazebo_scan_and_plan_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>picknik_ur_gazebo_scan_and_plan_config</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
 
   <description>Site configuration package for the UR5e simulated in Gazebo to show "scan and plan" applications.</description>
 

--- a/src/picknik_ur_mock_hw_config/package.xml
+++ b/src/picknik_ur_mock_hw_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>picknik_ur_mock_hw_config</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
 
   <description>Configuration package for a UR arm that can be simulated with mock hardware</description>
 

--- a/src/picknik_ur_site_config/package.xml
+++ b/src/picknik_ur_site_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>picknik_ur_site_config</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
 
   <description>Site configuration package for a UR arm that can be simulated with mock hardware</description>
 

--- a/src/picknik_ur_studio_integration_testing/package.xml
+++ b/src/picknik_ur_studio_integration_testing/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>picknik_ur_studio_integration_testing</name>
-  <version>4.0.1</version>
+  <version>5.0.0</version>
   <description>Integration tests for UR with MoveIt Pro.</description>
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>
 


### PR DESCRIPTION
This PR contains the needed changes to bump the version to the next minor release to main :eye: Please review that the changes are correct as the replacement of the version numbers is done automatically and can be wrong.
