### PR TITLE
update UR5 JTAC configs

### DIFF
--- a/src/picknik_ur_base_config/config/control/picknik_ur.ros2_control.yaml
+++ b/src/picknik_ur_base_config/config/control/picknik_ur.ros2_control.yaml
@@ -271,7 +271,14 @@ joint_trajectory_admittance_controller:
       - wrist_2_joint
       - wrist_3_joint
     base_frame: base_link
-    tip_frame: grasp_link
     sensor_frame: tool0
     ee_frame: grasp_link
     ft_sensor_name: tcp_fts_sensor
+    # Joint accelerations chosen to match MoveIt configs.
+    stop_accelerations:
+      - 30.0
+      - 30.0
+      - 30.0
+      - 30.0
+      - 30.0
+      - 30.0


### PR DESCRIPTION
Tip frame is no longer necessary.
Adds stop accelerations, matching MoveIt configs.