### PR TITLE
Remove moveit_pro_controllers as a dependency

### DIFF
--- a/src/picknik_ur_base_config/package.xml
+++ b/src/picknik_ur_base_config/package.xml
@@ -14,7 +14,6 @@
   <exec_depend>admittance_controller</exec_depend>
   <exec_depend>kinematics_interface_kdl</exec_depend>
   <exec_depend>moveit_planners_stomp</exec_depend>
-  <exec_depend>moveit_pro_controllers</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_studio_behavior</exec_depend>


### PR DESCRIPTION
As per @Abishalini 's help:

`moveit_pro_controllers` is not a package:
https://github.com/PickNikRobotics/moveit_studio/tree/main/src/moveit_pro_controllers

This causes the following error:
```
=> ERROR [rviz base 6/8] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/va  3.2s
------
 > [rviz base 6/8] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     . /opt/overlay_ws/install/setup.sh &&     apt-get update &&     rosdep install -q -y       --from-paths src       --ignore-src:
0.642 Hit:1 http://snapshots.ros.org/humble/2024-02-22/ubuntu jammy InRelease
0.777 Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
0.813 Hit:3 http://archive.ubuntu.com/ubuntu jammy InRelease
0.913 Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
1.019 Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
1.438 Reading package lists...
3.056 ERROR: the following packages/stacks could not have their rosdep keys resolved
3.056 to system dependencies:
3.056 picknik_ur_base_config: Cannot locate rosdep definition for [moveit_pro_controllers]
```

[Additional context](https://picknik.slack.com/archives/C01HWFR3KAB/p1715784850496859)