### PR TITLE
Revert "update JTAC plugin name (#274)"

### DIFF
--- a/src/picknik_ur_base_config/config/control/picknik_ur.ros2_control.yaml
+++ b/src/picknik_ur_base_config/config/control/picknik_ur.ros2_control.yaml
@@ -20,7 +20,7 @@ controller_manager:
     joint_trajectory_controller_chained_open_door:
       type: joint_trajectory_controller/JointTrajectoryController
     joint_trajectory_admittance_controller:
-      type: joint_trajectory_admittance_controller/JointTrajectoryAdmittanceController
+      type: moveit_pro_controllers/JointTrajectoryAdmittanceController
 
 io_and_status_controller:
   ros__parameters:

--- a/src/picknik_ur_base_config/package.xml
+++ b/src/picknik_ur_base_config/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>admittance_controller</exec_depend>
   <exec_depend>kinematics_interface_kdl</exec_depend>
   <exec_depend>moveit_planners_stomp</exec_depend>
+  <exec_depend>moveit_pro_controllers</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_studio_behavior</exec_depend>


### PR DESCRIPTION
This reverts commit a46b9ccb594f27a01686a8ccbb5f5a435262c81b.

The JTAC is still under the moveit_pro_controllers package in v5.1