### PR TITLE
Update Cycle Between Waypoints example to use Pro RRT

### DIFF
--- a/src/picknik_ur_mock_hw_config/objectives/cycle_between_waypoints.xml
+++ b/src/picknik_ur_mock_hw_config/objectives/cycle_between_waypoints.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
-  <root BTCPP_format="4" main_tree_to_execute="Cycle Between Waypoints">
-    <BehaviorTree ID="Cycle Between Waypoints" _description="Example of repeatedly moving between two saved poses." _favorite="true">
-        <Decorator ID="KeepRunningUntilFailure">
-            <Control ID="Sequence">
-                <SubTree ID="Move to Waypoint" waypoint_name="Look at Left Table" joint_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" planner_interface="moveit_default"/>
-                <SubTree ID="Move to Waypoint" waypoint_name="Look at Machine" joint_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" planner_interface="moveit_default"/>
-            </Control>
-        </Decorator>
-    </BehaviorTree>
+<?xml version='1.0' encoding='UTF-8'?>
+<root BTCPP_format="4" main_tree_to_execute="Cycle Between Waypoints">
+  <BehaviorTree ID="Cycle Between Waypoints" _description="Example of repeatedly moving between two saved poses." _favorite="true">
+    <Decorator ID="KeepRunningUntilFailure">
+      <Control ID="Sequence">
+        <SubTree ID="Move to Waypoint" waypoint_name="Grasp Left" joint_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" planner_interface="pro_rrt"/>
+        <SubTree ID="Move to Waypoint" waypoint_name="Grasp Right" joint_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" planner_interface="pro_rrt"/>
+      </Control>
+    </Decorator>
+  </BehaviorTree>
 </root>


### PR DESCRIPTION
Makes the `Cycle Between Waypoints` example Objective more compelling and working reliably.

The current waypoints `Look at Left Table` and `Look at Machine` are directly reachable, therefore they don't really exercise the planner. If you change them to `Grasp Left` and `Grasp Right` so that the planner has to make some work, the Objective becomes very flaky due to the tunneling problem: plans randomly fail with trajectory validation failures.

This PR changes the Objective to use the new RRT, which sets a different padding for planning vs. validation and makes it work reliably. Needs https://github.com/PickNikRobotics/moveit_studio/pull/8162.
