### PR TITLE
Update ROS1 to 2 Action Bridge for getMasks2D.

### DIFF
--- a/src/picknik_ur_site_config/CMakeLists.txt
+++ b/src/picknik_ur_site_config/CMakeLists.txt
@@ -9,6 +9,7 @@ moveit_studio_package()
 add_subdirectory(behaviors)
 
 install(
+  FILES action_bridge_mapping_rule.yaml
   DIRECTORY
     config
     # Uncomment the following lines if you make use of these directories in you site_config package

--- a/src/picknik_ur_site_config/config/action_bridge_mapping_rule.yaml
+++ b/src/picknik_ur_site_config/config/action_bridge_mapping_rule.yaml
@@ -1,0 +1,10 @@
+# This file defines mappings between ROS 1 and ROS 2 interfaces.
+# It is used with the ros1_bridge to allow for communication between ROS 1 and ROS 2.
+
+- 
+  ros1_package_name: 'moveit_studio_vision_msgs'
+  ros1_action_name: 'GetMasks2D'
+  ros2_package_name: 'picknik_ur_site_config'
+  ros2_action_name: 'GetMasks2D'
+  feedback_fields_1_to_2:
+    swquence: 'partial_sequence'

--- a/src/picknik_ur_site_config/package.xml
+++ b/src/picknik_ur_site_config/package.xml
@@ -18,5 +18,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <ros1_bridge mapping_rules="action_bridge_mapping_rule.yaml"/>
   </export>
 </package>


### PR DESCRIPTION
Demonstration of the mapping files needed for an action mapping as present in https://github.com/PickNikRobotics/ros2_demos/pull/2/files