### PR TITLE
Update mobile base config description

### DIFF
--- a/src/picknik_ur_mobile_config/config/config.yaml
+++ b/src/picknik_ur_mobile_config/config/config.yaml
@@ -81,9 +81,3 @@ ros2_control:
   # Optionally configure remapping rules to let multiple controllers receive commands on the same topic.
   # [Optional, default=[]]
   controller_shared_topics: []
-
-# Octomap manager configuration parameters
-octomap_manager:
-  # Input point cloud topic name. The *output* point cloud topic published by
-  # the Octomap manager node is defined in sensors_3d.yaml.
-  input_point_cloud_topic: "/wrist_camera/points"

--- a/src/picknik_ur_mobile_config/package.xml
+++ b/src/picknik_ur_mobile_config/package.xml
@@ -3,7 +3,7 @@
   <name>picknik_ur_mobile_config</name>
   <version>6.0.0</version>
 
-  <description>MuJoCo simulation configuration package for Picknik's UR robot on a linear rail</description>
+  <description>MuJoCo simulation configuration package for Picknik's UR robot on a mobile base</description>
 
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>
 


### PR DESCRIPTION
Updates the package.xml description and removes the octomap_manager from the config. This PR split out from PR #328 