### PR TITLE
Update deprecated param

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "src/external_dependencies/ros2_robotiq_gripper"]
 	path = src/external_dependencies/ros2_robotiq_gripper
 	url = https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+	branch = humble
 [submodule "src/external_dependencies/picknik_accessories"]
 	path = src/external_dependencies/picknik_accessories
 	url = https://github.com/PickNikRobotics/picknik_accessories.git

--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -55,7 +55,7 @@ hardware:
       - prefix: ""
       - use_fake_hardware: "true"
       - use_pinch_links: "true"
-      - fake_sensor_commands: "false"
+      - mock_sensor_commands: "false"
       - headless_mode: "true"
       - robot_ip: "0.0.0.0"
       - joint_limits_parameters_file:

--- a/src/picknik_ur_multi_arm_config/config/config.yaml
+++ b/src/picknik_ur_multi_arm_config/config/config.yaml
@@ -47,7 +47,7 @@ hardware:
       - prefix: ""
       - use_fake_hardware: "true"
       - use_pinch_links: "true"
-      - fake_sensor_commands: "false"
+      - mock_sensor_commands: "false"
       - headless_mode: "true"
       - robot_ip: "0.0.0.0"
       - joint_limits_parameters_file:


### PR DESCRIPTION
Fixes: [WARN] [1723039694.916396634] [mock_generic_system]: Parameter 'fake_sensor_commands' has been deprecated from usage. Use'mock_sensor_commands' instead.

TODO: Update ros2_robotiq_gripper once https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/61 is merged