### PR TITLE
Update `Pick Object` and `Place Object` in the `arm_on_rail_sim` to remove supervised autonomy Behaviors

### DIFF
--- a/src/arm_on_rail_sim/objectives/pick_object.xml
+++ b/src/arm_on_rail_sim/objectives/pick_object.xml
@@ -7,7 +7,6 @@
       <Control ID="Sequence">
         <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization"/>
         <Action ID="CreateStampedPose" orientation_xyzw="0;1;0;0" position_xyz="0.01;.75;0.515"/>
-        <!--Create a vector of poses to match the input of AdjustPoseWithIMarker-->
         <Action ID="AddPoseStampedToVector" input="{stamped_pose}" vector="{pose_vector}"/>
       </Control>
       <SubTree ID="Pick first object in vector" pose_vector="{pose_vector}" _collapsed="false"/>

--- a/src/arm_on_rail_sim/objectives/pick_object.xml
+++ b/src/arm_on_rail_sim/objectives/pick_object.xml
@@ -6,10 +6,9 @@
       <SubTree ID="Open Gripper"/>
       <Control ID="Sequence">
         <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization"/>
-        <Action ID="CreateStampedPose" orientation_xyzw="0;1;0;0" position_xyz="0.01;.75;0.525"/>
+        <Action ID="CreateStampedPose" orientation_xyzw="0;1;0;0" position_xyz="0.01;.75;0.515"/>
         <!--Create a vector of poses to match the input of AdjustPoseWithIMarker-->
-        <Action ID="AddPoseStampedToVector" input="{stamped_pose}" vector="{initial_poses}"/>
-        <Action ID="AdjustPoseWithIMarker" prompts="Adjust IMarker to desired pose" initial_poses="{initial_poses}" adjusted_poses="{pose_vector}"/>
+        <Action ID="AddPoseStampedToVector" input="{stamped_pose}" vector="{pose_vector}"/>
       </Control>
       <SubTree ID="Pick first object in vector" pose_vector="{pose_vector}" _collapsed="false"/>
     </Control>

--- a/src/arm_on_rail_sim/objectives/place_object.xml
+++ b/src/arm_on_rail_sim/objectives/place_object.xml
@@ -6,7 +6,6 @@
       <Control ID="Sequence">
         <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization"/>
         <Action ID="CreateStampedPose" orientation_xyzw="0;1;0;0" position_xyz="0.01;.75;0.5.15"/>
-        <!--Create a vector of poses to match the input of AdjustPoseWithIMarker-->
         <Action ID="AddPoseStampedToVector" input="{stamped_pose}" vector="{corrected_poses}"/>
       </Control>
       <!--Use the ForEach decorator to get a pose from our vector of poses-->

--- a/src/arm_on_rail_sim/objectives/place_object.xml
+++ b/src/arm_on_rail_sim/objectives/place_object.xml
@@ -5,10 +5,9 @@
     <Control ID="Sequence" name="root">
       <Control ID="Sequence">
         <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization"/>
-        <Action ID="CreateStampedPose" orientation_xyzw="0;1;0;0" position_xyz="0.01;.75;0.525"/>
+        <Action ID="CreateStampedPose" orientation_xyzw="0;1;0;0" position_xyz="0.01;.75;0.5.15"/>
         <!--Create a vector of poses to match the input of AdjustPoseWithIMarker-->
-        <Action ID="AddPoseStampedToVector" input="{stamped_pose}" vector="{initial_poses}"/>
-        <Action ID="AdjustPoseWithIMarker" adjusted_poses="{corrected_poses}" prompts="Adjust place position"/>
+        <Action ID="AddPoseStampedToVector" input="{stamped_pose}" vector="{corrected_poses}"/>
       </Control>
       <!--Use the ForEach decorator to get a pose from our vector of poses-->
       <SubTree ID="Place first object in vector" pose_vector="{corrected_poses}" _collapsed="false"/>


### PR DESCRIPTION
Resolves https://github.com/PickNikRobotics/moveit_studio/issues/8285.

This PR updates the `Pick Object` and `Place Object` Objectives in the `arm_on_rail_sim` config to remove the `AdjustPoseWithIMarker` Behavior and instead use a hard-coded pose.

### To test:
1) Run MoveIt Pro with the `arm_on_rail_sim` Objective.
2) Run the `Pick Object` Objective. It should succeed without using the `AdjustPoseWithIMarker` Behavior.
3) Run the `Place Object` Objective. There is a high chance it fails at the end, but that is not the point of this PR. It should get all the way to the end without the `AdjustPoseWithIMarker` Behavior.
