### PR TITLE
Correct the FTS broadcaster frame (which we don't directly use) and r…

### DIFF
--- a/src/arm_on_rail_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/arm_on_rail_sim/config/control/picknik_ur.ros2_control.yaml
@@ -154,7 +154,7 @@ force_torque_sensor_broadcaster:
       - torque.x
       - torque.y
       - torque.z
-    frame_id: fts_link
+    frame_id: robotiq_ft_sensor
 
 
 joint_trajectory_admittance_controller:

--- a/src/arm_on_rail_sim/description/ur5e.xml
+++ b/src/arm_on_rail_sim/description/ur5e.xml
@@ -771,7 +771,7 @@
   </equality>
 
   <sensor>
-    <force name="ee_force_sensor" site="robotiq_ft_sensor" />
-    <torque name="ee_torque_sensor" site="robotiq_ft_sensor" />
+    <force site="robotiq_ft_sensor" />
+    <torque site="robotiq_ft_sensor" />
   </sensor>
 </mujoco>

--- a/src/picknik_ur_mobile_config/config/control/picknik_ur.ros2_control.yaml
+++ b/src/picknik_ur_mobile_config/config/control/picknik_ur.ros2_control.yaml
@@ -172,4 +172,4 @@ force_torque_sensor_broadcaster:
       - torque.x
       - torque.y
       - torque.z
-    frame_id: fts_link
+    frame_id: robotiq_ft_sensor

--- a/src/picknik_ur_mobile_config/description/ur5e.xml
+++ b/src/picknik_ur_mobile_config/description/ur5e.xml
@@ -892,8 +892,8 @@
   </equality>
 
   <sensor>
-    <force name="ee_force_sensor" site="robotiq_ft_sensor" />
-    <torque name="ee_torque_sensor" site="robotiq_ft_sensor" />
+    <force site="robotiq_ft_sensor" />
+    <torque site="robotiq_ft_sensor" />
   </sensor>
 
   <keyframe>


### PR DESCRIPTION
I do not think we actually use this frame, but the frame in the Header was being populated with a non-existent frame.

This also remove names from the mujoco force and torque tags as they are not used by mujoco_system.