### PR TITLE
Fix for gazebo configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,4 +82,4 @@ repos:
         additional_dependencies:
           - "prettier@3.1.0"
           - "@prettier/plugin-xml@3.3.1"
-        files: \.(xml|xacro)$
+        files: \.(xml)$

--- a/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
+++ b/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
@@ -125,8 +125,7 @@
       name="ign_ros2_control::IgnitionROS2ControlPlugin"
     >
       <parameters>
-        $(find
-        picknik_ur_gazebo_config)/config/control/picknik_ur5e.ros2_control.yaml
+        $(find picknik_ur_gazebo_config)/config/control/picknik_ur5e.ros2_control.yaml
       </parameters>
       <ros>
         <remapping>


### PR DESCRIPTION
I'm not sure there is any way to prevent the linter from breaking a line like this in some other config, so I think maybe we just dont lint xacros?