### PR TITLE
Update mobile manipulation config objectives (fixes #8763)

### DIFF
--- a/src/mobile_manipulation_config/objectives/04_solution_-_move_to_a_pose.xml
+++ b/src/mobile_manipulation_config/objectives/04_solution_-_move_to_a_pose.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="04 Solution - Move to a Pose">
   <!--//////////-->
   <BehaviorTree

--- a/src/mobile_manipulation_config/objectives/20_solution_-_look_at_the_airfoil.xml
+++ b/src/mobile_manipulation_config/objectives/20_solution_-_look_at_the_airfoil.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="20 Solution - Look at the airfoil">
   <!--//////////-->
   <BehaviorTree

--- a/src/mobile_manipulation_config/objectives/21_solution_-_find_the_airfoil.xml
+++ b/src/mobile_manipulation_config/objectives/21_solution_-_find_the_airfoil.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="21 Solution - Find the airfoil">
   <!--//////////-->
   <BehaviorTree
@@ -18,12 +17,13 @@
       />
       <SubTree
         ID="Estimate Object Pose"
-        object_model_file_path="~/user_ws/install/mobile_manipulation_config/share/mobile_manipulation_config/description/assets/airfoil.stl"
+        object_model_file_path="description/assets/airfoil.stl"
         guess_position="4.5;0.0;0.5"
         guess_orientation="0.0;0.0;0.7071;0.7071"
         icp_max_correspondence_distance="0.5"
         model_to_real_pose="{model_to_real_pose}"
         _collapsed="true"
+        package_name="mobile_manipulation_config"
       />
     </Control>
   </BehaviorTree>

--- a/src/mobile_manipulation_config/objectives/22_solution_-_visualize_airfoil_frame.xml
+++ b/src/mobile_manipulation_config/objectives/22_solution_-_visualize_airfoil_frame.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <root
   BTCPP_format="4"
   main_tree_to_execute="22 Solution - Visualize airfoil frame"
@@ -21,12 +20,13 @@
       />
       <SubTree
         ID="Estimate Object Pose"
-        object_model_file_path="~/user_ws/install/mobile_manipulation_config/share/mobile_manipulation_config/description/assets/airfoil.stl"
+        object_model_file_path="description/assets/airfoil.stl"
         guess_position="4.5;0.0;0.5"
         guess_orientation="0.0;0.0;0.7071;0.7071"
         icp_max_correspondence_distance="0.5"
         model_to_real_pose="{model_to_real_pose}"
         _collapsed="true"
+        package_name="mobile_manipulation_config"
       />
       <Action ID="VisualizePose" pose="{model_to_real_pose}" />
     </Control>

--- a/src/mobile_manipulation_config/objectives/23_solution_-_airfoil_coverage_origin.xml
+++ b/src/mobile_manipulation_config/objectives/23_solution_-_airfoil_coverage_origin.xml
@@ -21,12 +21,13 @@
       />
       <SubTree
         ID="Estimate Object Pose"
-        object_model_file_path="~/user_ws/install/mobile_manipulation_config/share/mobile_manipulation_config/description/assets/airfoil.stl"
+        object_model_file_path="description/assets/airfoil.stl"
         guess_position="4.5;0.0;0.5"
         guess_orientation="0.0;0.0;0.7071;0.7071"
         icp_max_correspondence_distance="0.5"
         model_to_real_pose="{model_to_real_pose}"
         _collapsed="true"
+        package_name="mobile_manipulation_config"
       />
       <Action
         ID="TransformPose"

--- a/src/mobile_manipulation_config/objectives/24_solution_-_airfoil_coverage_path.xml
+++ b/src/mobile_manipulation_config/objectives/24_solution_-_airfoil_coverage_path.xml
@@ -21,12 +21,13 @@
       />
       <SubTree
         ID="Estimate Object Pose"
-        object_model_file_path="~/user_ws/install/mobile_manipulation_config/share/mobile_manipulation_config/description/assets/airfoil.stl"
+        object_model_file_path="description/assets/airfoil.stl"
         guess_position="4.5;0.0;0.5"
         guess_orientation="0.0;0.0;0.7071;0.7071"
         icp_max_correspondence_distance="0.5"
         model_to_real_pose="{model_to_real_pose}"
         _collapsed="true"
+        package_name="mobile_manipulation_config"
       />
       <Action
         ID="TransformPose"

--- a/src/mobile_manipulation_config/objectives/25_solution_-_execute_airfoil_coverage.xml
+++ b/src/mobile_manipulation_config/objectives/25_solution_-_execute_airfoil_coverage.xml
@@ -21,12 +21,13 @@
       />
       <SubTree
         ID="Estimate Object Pose"
-        object_model_file_path="~/user_ws/install/mobile_manipulation_config/share/mobile_manipulation_config/description/assets/airfoil.stl"
+        object_model_file_path="description/assets/airfoil.stl"
         guess_position="4.5;0.0;0.5"
         guess_orientation="0.0;0.0;0.7071;0.7071"
         icp_max_correspondence_distance="0.5"
         model_to_real_pose="{model_to_real_pose}"
         _collapsed="true"
+        package_name="mobile_manipulation_config"
       />
       <Action
         ID="TransformPose"

--- a/src/mobile_manipulation_config/objectives/26_solution_-_better_coverage.xml
+++ b/src/mobile_manipulation_config/objectives/26_solution_-_better_coverage.xml
@@ -18,12 +18,13 @@
       />
       <SubTree
         ID="Estimate Object Pose"
-        object_model_file_path="~/user_ws/install/mobile_manipulation_config/share/mobile_manipulation_config/description/assets/airfoil.stl"
+        object_model_file_path="description/assets/airfoil.stl"
         guess_position="4.5;0.0;0.5"
-        guess_orientation="0.0;0.0;0.7071068; 0.7071068"
+        guess_orientation="0.0;0.0;0.7071;0.7071"
         icp_max_correspondence_distance="0.5"
         model_to_real_pose="{model_to_real_pose}"
         _collapsed="true"
+        package_name="mobile_manipulation_config"
       />
       <Action
         ID="TransformPose"

--- a/src/mobile_manipulation_config/objectives/estimate_object_pose.xml
+++ b/src/mobile_manipulation_config/objectives/estimate_object_pose.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Estimate Object Pose">
   <!--//////////-->
   <BehaviorTree
@@ -18,6 +17,7 @@
         point_cloud="{model_point_cloud}"
         scale="1.0"
         color="255;150;0"
+        package_name="{package_name}"
       />
       <Action
         ID="GetSyncedImageAndPointCloud"
@@ -71,6 +71,8 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Estimate Object Pose" />
+    <SubTree ID="Estimate Object Pose">
+      <input_port name="package_name" default="mobile_manipulation_config" />
+    </SubTree>
   </TreeNodesModel>
 </root>


### PR DESCRIPTION
This fixes https://github.com/PickNikRobotics/moveit_studio/issues/8763

The issue is that the `LoadPointCloudFromFile` can't resolve a path with `~/user_ws/` so a package relative path is used instead. This puts `mobile_manipulation_config` into the `{package_name}` blackboard variable, and passes that to the behavior.