### PR TITLE
Removing primary view switch in teleop Joints Jog

### DIFF
--- a/src/picknik_ur_base_config/objectives/request_teleoperation.xml
+++ b/src/picknik_ur_base_config/objectives/request_teleoperation.xml
@@ -153,10 +153,10 @@
               />
             </Control>
             <Control ID="Sequence" _while="teleop_mode == 1">
-              <Action
+              <!-- <Action
                 ID="SwitchUIPrimaryView"
                 primary_view_name="Visualization"
-              />
+              /> -->
               <Action
                 ID="TeleoperateJointJog"
                 controller_name="servo_controller"

--- a/src/picknik_ur_base_config/objectives/request_teleoperation.xml
+++ b/src/picknik_ur_base_config/objectives/request_teleoperation.xml
@@ -30,10 +30,6 @@
             <!--Joint sliders interpolate to joint state-->
             <Decorator ID="ForceSuccess" _while="teleop_mode == 5">
               <Control ID="Sequence">
-                <!-- <Action
-                  ID="SwitchUIPrimaryView"
-                  primary_view_name="Visualization"
-                /> -->
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action
@@ -153,10 +149,6 @@
               />
             </Control>
             <Control ID="Sequence" _while="teleop_mode == 1">
-              <!-- <Action
-                ID="SwitchUIPrimaryView"
-                primary_view_name="Visualization"
-              /> -->
               <Action
                 ID="TeleoperateJointJog"
                 controller_name="servo_controller"

--- a/src/picknik_ur_base_config/objectives/request_teleoperation.xml
+++ b/src/picknik_ur_base_config/objectives/request_teleoperation.xml
@@ -30,10 +30,10 @@
             <!--Joint sliders interpolate to joint state-->
             <Decorator ID="ForceSuccess" _while="teleop_mode == 5">
               <Control ID="Sequence">
-                <Action
+                <!-- <Action
                   ID="SwitchUIPrimaryView"
                   primary_view_name="Visualization"
-                />
+                /> -->
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action


### PR DESCRIPTION
This is a removal of two `switchUIPrimaryView' behaviors. They are both tied to the `RequestTeleoperation` subtree. They are being removed so that in multi pane view when moving the sliders the view does not jump back to the main pane. 