### PR TITLE
Remove colcon build step from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,10 +119,6 @@ ENV USER_WS=${USER_WS}
 
 # Compile the workspace
 WORKDIR $USER_WS
-# hadolint ignore=SC1091
-RUN --mount=type=cache,target=/home/${USERNAME}/.ccache \
-    . /opt/overlay_ws/install/setup.sh && \
-    colcon build
 
 # Set up the user's .bashrc file and shell.
 CMD ["/usr/bin/bash"]


### PR DESCRIPTION
You shouldn't have to build your workspace to get a docker image, and this step is super frustrating if you have broken packages but no way to quickly build them.

With this line removed, you can build a Pro image with a workspace that has broken packages. Then using `moveit_pro build user_workspace` you can more easily iterate on and fix your broken package