### PR TITLE
Clean some ARGS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@
 #
 
 # Specify the MoveIt Pro release to build on top of.
-ARG MOVEIT_STUDIO_BASE_IMAGE
-ENV MOVEIT_STUDIO_BASE_IMAGE=MOVEIT_STUDIO_BASE_IMAGE
+ARG MOVEIT_STUDIO_BASE_IMAGE=main
 
 ##################################################
 # Starting from the specified MoveIt Pro release #

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@
 
 # Specify the MoveIt Pro release to build on top of.
 ARG MOVEIT_STUDIO_BASE_IMAGE
-ARG USERNAME=studio-user
-ARG USER_UID=1000
-ARG USER_GID=1000
+ENV MOVEIT_STUDIO_BASE_IMAGE=MOVEIT_STUDIO_BASE_IMAGE
 
 ##################################################
 # Starting from the specified MoveIt Pro release #
@@ -22,7 +20,6 @@ FROM ${MOVEIT_STUDIO_BASE_IMAGE} AS base
 ARG USERNAME
 ARG USER_UID
 ARG USER_GID
-
 # Copy source code from the workspace's ROS 2 packages to a workspace inside the container
 ARG USER_WS=/home/${USERNAME}/user_ws
 ENV USER_WS=${USER_WS}


### PR DESCRIPTION
This should fix the 
```
=> WARN: InvalidDefaultArgInFrom: Default value for ARG ${MOVEIT_STUDIO_BASE_IMAGE} results in empty or invalid base image
```
warnings on building this USER WS.