### PR TITLE
Refactor gripper move groups to use chains instead of links.

### DIFF
--- a/src/arm_on_rail_sim/config/moveit/picknik_ur.srdf
+++ b/src/arm_on_rail_sim/config/moveit/picknik_ur.srdf
@@ -17,17 +17,9 @@
         <group name="linear_actuator" />
     </group>
     <group name="gripper">
-        <link name="robotiq_85_base_link"/>
-        <link name="robotiq_85_left_inner_knuckle_link"/>
-        <link name="robotiq_85_left_finger_tip_link"/>
-        <link name="robotiq_85_left_knuckle_link"/>
-        <link name="robotiq_85_left_finger_link"/>
-        <link name="robotiq_85_right_inner_knuckle_link"/>
-        <link name="robotiq_85_right_finger_tip_link"/>
-        <link name="robotiq_85_right_knuckle_link"/>
-        <link name="robotiq_85_right_finger_link"/>
-        <link name="grasp_link"/>
-        <joint name="robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="grasp_link"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="open" group="gripper">

--- a/src/picknik_ur_base_config/config/moveit/picknik_ur.srdf
+++ b/src/picknik_ur_base_config/config/moveit/picknik_ur.srdf
@@ -13,17 +13,9 @@
         <chain base_link="base_link" tip_link="grasp_link"/>
     </group>
     <group name="gripper">
-        <link name="robotiq_85_base_link"/>
-        <link name="robotiq_85_left_inner_knuckle_link"/>
-        <link name="robotiq_85_left_finger_tip_link"/>
-        <link name="robotiq_85_left_knuckle_link"/>
-        <link name="robotiq_85_left_finger_link"/>
-        <link name="robotiq_85_right_inner_knuckle_link"/>
-        <link name="robotiq_85_right_finger_tip_link"/>
-        <link name="robotiq_85_right_knuckle_link"/>
-        <link name="robotiq_85_right_finger_link"/>
-        <link name="grasp_link"/>
-        <joint name="robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="grasp_link"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="open" group="gripper">

--- a/src/picknik_ur_gazebo_config/config/moveit/picknik_ur_gazebo.srdf.xacro
+++ b/src/picknik_ur_gazebo_config/config/moveit/picknik_ur_gazebo.srdf.xacro
@@ -16,17 +16,9 @@
     <chain base_link="base_link" tip_link="grasp_link" />
   </group>
   <group name="gripper">
-    <link name="$(arg gripper_name)_base_link" />
-    <link name="$(arg gripper_name)_left_inner_knuckle_link" />
-    <link name="$(arg gripper_name)_left_finger_tip_link" />
-    <link name="$(arg gripper_name)_left_knuckle_link" />
-    <link name="$(arg gripper_name)_left_finger_link" />
-    <link name="$(arg gripper_name)_right_inner_knuckle_link" />
-    <link name="$(arg gripper_name)_right_finger_tip_link" />
-    <link name="$(arg gripper_name)_right_knuckle_link" />
-    <link name="$(arg gripper_name)_right_finger_link" />
-    <link name="grasp_link" />
-    <joint name="$(arg gripper_name)_left_knuckle_joint" />
+    <chain base_link="robotiq_85_base_link" tip_link="$(arg gripper_name)_left_finger_link"/>
+    <chain base_link="robotiq_85_base_link" tip_link="$(arg gripper_name)_right_finger_link"/>
+    <chain base_link="robotiq_85_base_link" tip_link="grasp_link"/>
   </group>
   <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
   <group_state name="open" group="gripper">

--- a/src/picknik_ur_gazebo_config/config/moveit/picknik_ur_gazebo.srdf.xacro
+++ b/src/picknik_ur_gazebo_config/config/moveit/picknik_ur_gazebo.srdf.xacro
@@ -16,9 +16,9 @@
     <chain base_link="base_link" tip_link="grasp_link" />
   </group>
   <group name="gripper">
-    <chain base_link="robotiq_85_base_link" tip_link="$(arg gripper_name)_left_finger_link"/>
-    <chain base_link="robotiq_85_base_link" tip_link="$(arg gripper_name)_right_finger_link"/>
-    <chain base_link="robotiq_85_base_link" tip_link="grasp_link"/>
+    <chain base_link="(arg gripper_name)_base_link" tip_link="$(arg gripper_name)_left_finger_link"/>
+    <chain base_link="(arg gripper_name)_base_link" tip_link="$(arg gripper_name)_right_finger_link"/>
+    <chain base_link="(arg gripper_name)_base_link" tip_link="grasp_link"/>
   </group>
   <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
   <group_state name="open" group="gripper">

--- a/src/picknik_ur_mobile_config/config/moveit/picknik_ur.srdf
+++ b/src/picknik_ur_mobile_config/config/moveit/picknik_ur.srdf
@@ -19,17 +19,9 @@
         <group name="linear_actuator" />
     </group>
     <group name="gripper">
-        <link name="robotiq_85_base_link"/>
-        <link name="robotiq_85_left_inner_knuckle_link"/>
-        <link name="robotiq_85_left_finger_tip_link"/>
-        <link name="robotiq_85_left_knuckle_link"/>
-        <link name="robotiq_85_left_finger_link"/>
-        <link name="robotiq_85_right_inner_knuckle_link"/>
-        <link name="robotiq_85_right_finger_tip_link"/>
-        <link name="robotiq_85_right_knuckle_link"/>
-        <link name="robotiq_85_right_finger_link"/>
-        <link name="grasp_link"/>
-        <joint name="robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="grasp_link"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="open" group="gripper">

--- a/src/picknik_ur_mock_hw_config/config/moveit/picknik_ur_machine_tending.srdf
+++ b/src/picknik_ur_mock_hw_config/config/moveit/picknik_ur_machine_tending.srdf
@@ -13,17 +13,9 @@
         <chain base_link="base_link" tip_link="grasp_link"/>
     </group>
     <group name="gripper">
-        <link name="robotiq_85_base_link"/>
-        <link name="robotiq_85_left_inner_knuckle_link"/>
-        <link name="robotiq_85_left_finger_tip_link"/>
-        <link name="robotiq_85_left_knuckle_link"/>
-        <link name="robotiq_85_left_finger_link"/>
-        <link name="robotiq_85_right_inner_knuckle_link"/>
-        <link name="robotiq_85_right_finger_tip_link"/>
-        <link name="robotiq_85_right_knuckle_link"/>
-        <link name="robotiq_85_right_finger_link"/>
-        <link name="grasp_link"/>
-        <joint name="robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="grasp_link"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="open" group="gripper">

--- a/src/picknik_ur_multi_arm_config/config/moveit/multi_arm_ur.srdf
+++ b/src/picknik_ur_multi_arm_config/config/moveit/multi_arm_ur.srdf
@@ -28,24 +28,24 @@
         <group name="fourth_manipulator"/>
     </group>
     <group name="gripper">
-        <chain base_link="robotiq_85_base_link" tip_link="first_robotiq_85_left_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="first_robotiq_85_right_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="first_grasp_link"/>
+        <chain base_link="first_robotiq_85_base_link" tip_link="first_robotiq_85_left_finger_link"/>
+        <chain base_link="first_robotiq_85_base_link" tip_link="first_robotiq_85_right_finger_link"/>
+        <chain base_link="first_robotiq_85_base_link" tip_link="first_grasp_link"/>
     </group>
     <group name="second_gripper">
-        <chain base_link="robotiq_85_base_link" tip_link="second_robotiq_85_left_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="second_robotiq_85_right_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="second_grasp_link"/>
+        <chain base_link="second_robotiq_85_base_link" tip_link="second_robotiq_85_left_finger_link"/>
+        <chain base_link="second_robotiq_85_base_link" tip_link="second_robotiq_85_right_finger_link"/>
+        <chain base_link="second_robotiq_85_base_link" tip_link="second_grasp_link"/>
     </group>
     <group name="third_gripper">
-        <chain base_link="robotiq_85_base_link" tip_link="third_robotiq_85_left_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="third_robotiq_85_right_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="third_grasp_link"/>
+        <chain base_link="third_robotiq_85_base_link" tip_link="third_robotiq_85_left_finger_link"/>
+        <chain base_link="third_robotiq_85_base_link" tip_link="third_robotiq_85_right_finger_link"/>
+        <chain base_link="third_robotiq_85_base_link" tip_link="third_grasp_link"/>
     </group>
     <group name="fourth_gripper">
-        <chain base_link="robotiq_85_base_link" tip_link="fourth_robotiq_85_left_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="fourth_robotiq_85_right_finger_link"/>
-        <chain base_link="robotiq_85_base_link" tip_link="fourth_grasp_link"/>
+        <chain base_link="fourth_robotiq_85_base_link" tip_link="fourth_robotiq_85_left_finger_link"/>
+        <chain base_link="fourth_robotiq_85_base_link" tip_link="fourth_robotiq_85_right_finger_link"/>
+        <chain base_link="fourth_robotiq_85_base_link" tip_link="fourth_grasp_link"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="open_right" group="gripper">

--- a/src/picknik_ur_multi_arm_config/config/moveit/multi_arm_ur.srdf
+++ b/src/picknik_ur_multi_arm_config/config/moveit/multi_arm_ur.srdf
@@ -28,56 +28,24 @@
         <group name="fourth_manipulator"/>
     </group>
     <group name="gripper">
-        <link name="first_robotiq_85_base_link"/>
-        <link name="first_robotiq_85_left_inner_knuckle_link"/>
-        <link name="first_robotiq_85_left_finger_tip_link"/>
-        <link name="first_robotiq_85_left_knuckle_link"/>
-        <link name="first_robotiq_85_left_finger_link"/>
-        <link name="first_robotiq_85_right_inner_knuckle_link"/>
-        <link name="first_robotiq_85_right_finger_tip_link"/>
-        <link name="first_robotiq_85_right_knuckle_link"/>
-        <link name="first_robotiq_85_right_finger_link"/>
-        <link name="first_grasp_link"/>
-        <joint name="first_robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="first_robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="first_robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="first_grasp_link"/>
     </group>
     <group name="second_gripper">
-        <link name="second_robotiq_85_base_link"/>
-        <link name="second_robotiq_85_left_inner_knuckle_link"/>
-        <link name="second_robotiq_85_left_finger_tip_link"/>
-        <link name="second_robotiq_85_left_knuckle_link"/>
-        <link name="second_robotiq_85_left_finger_link"/>
-        <link name="second_robotiq_85_right_inner_knuckle_link"/>
-        <link name="second_robotiq_85_right_finger_tip_link"/>
-        <link name="second_robotiq_85_right_knuckle_link"/>
-        <link name="second_robotiq_85_right_finger_link"/>
-        <link name="second_grasp_link"/>
-        <joint name="second_robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="second_robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="second_robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="second_grasp_link"/>
     </group>
     <group name="third_gripper">
-        <link name="third_robotiq_85_base_link"/>
-        <link name="third_robotiq_85_left_inner_knuckle_link"/>
-        <link name="third_robotiq_85_left_finger_tip_link"/>
-        <link name="third_robotiq_85_left_knuckle_link"/>
-        <link name="third_robotiq_85_left_finger_link"/>
-        <link name="third_robotiq_85_right_inner_knuckle_link"/>
-        <link name="third_robotiq_85_right_finger_tip_link"/>
-        <link name="third_robotiq_85_right_knuckle_link"/>
-        <link name="third_robotiq_85_right_finger_link"/>
-        <link name="third_grasp_link"/>
-        <joint name="third_robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="third_robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="third_robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="third_grasp_link"/>
     </group>
     <group name="fourth_gripper">
-        <link name="fourth_robotiq_85_base_link"/>
-        <link name="fourth_robotiq_85_left_inner_knuckle_link"/>
-        <link name="fourth_robotiq_85_left_finger_tip_link"/>
-        <link name="fourth_robotiq_85_left_knuckle_link"/>
-        <link name="fourth_robotiq_85_left_finger_link"/>
-        <link name="fourth_robotiq_85_right_inner_knuckle_link"/>
-        <link name="fourth_robotiq_85_right_finger_tip_link"/>
-        <link name="fourth_robotiq_85_right_knuckle_link"/>
-        <link name="fourth_robotiq_85_right_finger_link"/>
-        <link name="fourth_grasp_link"/>
-        <joint name="fourth_robotiq_85_left_knuckle_joint"/>
+        <chain base_link="robotiq_85_base_link" tip_link="fourth_robotiq_85_left_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="fourth_robotiq_85_right_finger_link"/>
+        <chain base_link="robotiq_85_base_link" tip_link="fourth_grasp_link"/>
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="open_right" group="gripper">


### PR DESCRIPTION
Closes [#8102](https://github.com/PickNikRobotics/moveit_studio/issues/8102)

Simplify planning groups in config SRDFs to use chains as opposed to list of links.